### PR TITLE
Document API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This project automates the pipeline between open satellite APIs and professional
 
 ```bash
 pip install -r requirements.txt
+```
 
 
 🔐 Environment Variables
@@ -56,6 +57,19 @@ Expand automation to multiple regions
 MIT © 2025 Jethro
 
 ---
+
+## Running the Job API
+
+This repository includes a small FastAPI app that runs jobs defined in the
+`scripts/` folder. Install the dependencies and launch it with:
+
+```bash
+uvicorn apscheduler_api.main:app --reload
+```
+
+Once running, trigger a job by sending a POST request to `/run-job/{job_name}`.
+See [docs/api_usage.md](docs/api_usage.md) for a full list of jobs and example
+commands.
 
 If you’d like a visual badge setup, GitHub Actions CI trigger, or even a contributor’s guide section, I can snap those in next. Want to keep evolving this into a full-blown dashboard or newsletter tool? I’m ready when you are! 😎📈
 

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -1,0 +1,34 @@
+# API Usage
+
+This project bundles a minimal FastAPI app so you can run the automation scripts on demand.
+
+## Start the server
+
+Install the requirements and start Uvicorn pointing at the app:
+
+```bash
+pip install -r requirements.txt
+uvicorn apscheduler_api.main:app --reload
+```
+
+The server will run on <http://localhost:8000> by default.
+
+## Trigger a job
+
+Send a POST request to `/run-job/{job_name}` where `job_name` matches a Python script inside the `scripts/` folder. Example:
+
+```bash
+curl -X POST http://localhost:8000/run-job/fetch_satellite_data
+```
+
+The API responds with `{"status": "success", "job": "fetch_satellite_data"}` if the job completes without raising an exception.
+
+## Available jobs
+
+Below are the job names you can call and what each script does:
+
+- `fetch_satellite_data` – Downloads NO₂ satellite imagery from NASA GIBS, pulls matching data from the Caeli API and stores comparisons in `data/no2_comparison_data.csv`.
+- `generate_chart` – Reads `data/processed_pollution.csv` and generates a trend chart saved in `charts/`.
+- `list_gibs_layers` – Lists all map layers provided by the NASA GIBS WMS service.
+- `ptest` – Monitors network connectivity and attempts router reboot and DNS flush if the connection fails.
+


### PR DESCRIPTION
## Summary
- document how to run the FastAPI job runner
- list available job names in a new `docs/api_usage.md`
- fix README code block and link to the new docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688d34c13c6083249349dd05e266d70e